### PR TITLE
Restructured the haproxy role for better readability

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,15 @@ haproxy_bind_on_non_local: False
 haproxy_config_fragments_folder: "/etc/haproxy/conf.d"
 haproxy_cleanup_fragments: False
 
+### if you don't have the luxury to do a skip tags in command line,
+## you may want to override this in order to execute only the tasks
+## you want to run.
+##haproxy_run_steps:
+haproxy_pre_install: True
+haproxy_install: True
+haproxy_post_install: True
+haproxy_config: True
+
 ## HAproxy base configuration variables. cf. vars/haproxy_* files.
 haproxy_defaults: {}
 haproxy_global: {}

--- a/tasks/haproxy_add_apt_repo.yml
+++ b/tasks/haproxy_add_apt_repo.yml
@@ -19,7 +19,6 @@
     state: present
     update_cache: yes
   tags:
-    - haproxy-repos
     - haproxy-apt-repos
 
 #- name: Drop haproxy repo pin

--- a/tasks/haproxy_add_epel_repo.yml
+++ b/tasks/haproxy_add_epel_repo.yml
@@ -17,7 +17,6 @@
   shell: yum repolist | grep -qi EPEL
   register: epel_repo_present
   tags:
-    - haproxy-repos
     - haproxy-yum-repos
 
 - name: Add epel repo
@@ -29,5 +28,4 @@
     mode: "0644"
   when: epel_repo_present.rc != 0
   tags:
-    - haproxy-repos
     - haproxy-yum-repos

--- a/tasks/haproxy_config.yml
+++ b/tasks/haproxy_config.yml
@@ -1,0 +1,53 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Cleaning up the fragments folder
+  file:
+    path: "{{ haproxy_config_fragments_folder }}"
+    state: absent
+  when: haproxy_cleanup_fragments | bool
+  tags:
+    - haproxy-cleanup
+    - haproxy-fragments
+
+- name: The configuration fragments folder should exist
+  file:
+    path: "{{ haproxy_config_fragments_folder }}"
+    state: directory
+    recurse: yes
+  tags:
+    - haproxy-fragments
+
+#- name: Making sure the fragment folder exists
+#  file:
+#    path: "{{ haproxy_config_fragments_folder}}"
+#    state: directory
+
+- name: Drop base haproxy config
+  template:
+    src: haproxy.cfg.j2
+    dest: "{{ haproxy_config_fragments_folder }}/00-haproxy.cfg"
+  notify: Regenerate haproxy configuration
+  tags:
+    - haproxy-base-config
+
+- name: Generate files for the frontends and backends
+  template:
+    src: service.j2
+    dest: "{{ haproxy_config_fragments_folder }}/{{ item.key }}"
+  with_dict: haproxy_services
+  notify: Regenerate haproxy configuration
+  tags:
+    - haproxy-service-config

--- a/tasks/haproxy_install.yml
+++ b/tasks/haproxy_install.yml
@@ -29,6 +29,7 @@
   when: ansible_os_family == 'RedHat'
   notify: Restart haproxy
   tags:
+    - haproxy-packages
     - haproxy-yum-packages
 
 - name: Installs haproxy packages by apt
@@ -39,6 +40,7 @@
   when: ansible_os_family == 'Debian'
   notify: Restart haproxy
   tags:
+    - haproxy-packages
     - haproxy-apt-packages
 
 - name: Installs haproxy packages by pkgin
@@ -49,6 +51,7 @@
   when: ansible_os_family == 'Solaris'
   notify: Restart haproxy
   tags:
+    - haproxy-packages
     - haproxy-pkgin-packages
 
 #Disabling the conf.d idea to be closer to upstream.

--- a/tasks/haproxy_post_install.yml
+++ b/tasks/haproxy_post_install.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- include: haproxy_ssl.yml
+  when: haproxy_ssl | bool
+  tags:
+    - haproxy-ssl
+
 - name: Make haproxy bindable on non local addresses
   sysctl:
     name: net.ipv4.ip_nonlocal_bind
@@ -22,44 +27,3 @@
   when: haproxy_bind_on_non_local | bool
   tags:
     - haproxy-sysctl
-
-- name: Cleaning up the fragments folder
-  file:
-    path: "{{ haproxy_config_fragments_folder }}"
-    state: absent
-  when: haproxy_cleanup_fragments | bool
-  tags:
-    - haproxy-cleanup
-    - haproxy-config
-
-- name: The configuration fragments folder should exist
-  file:
-    path: "{{ haproxy_config_fragments_folder }}"
-    state: directory
-    recurse: yes
-  tags:
-    - haproxy-config
-
-#- name: Making sure the fragment folder exists
-#  file:
-#    path: "{{ haproxy_config_fragments_folder}}"
-#    state: directory
-
-- name: Drop base haproxy config
-  template:
-    src: haproxy.cfg.j2
-    dest: "{{ haproxy_config_fragments_folder }}/00-haproxy.cfg"
-  notify: Regenerate haproxy configuration
-  tags:
-    - haproxy-config
-    - haproxy-base-config
-
-- name: Generate files for the frontends and backends
-  template:
-    src: service.j2
-    dest: "{{ haproxy_config_fragments_folder }}/{{ item.key }}"
-  with_dict: haproxy_services
-  notify: Regenerate haproxy configuration
-  tags:
-    - haproxy-config
-    - haproxy-service-config

--- a/tasks/haproxy_pre_install.yml
+++ b/tasks/haproxy_pre_install.yml
@@ -15,12 +15,16 @@
 
 # EPEL is only needed if Centos/RHEL < 5
 - include: haproxy_add_epel_repo.yml
-  when: >
-    ansible_os_family == 'RedHat' and
-    (ansible_distribution_major_version | version_compare ('5','<'))
+  when:
+    - ansible_os_family == 'RedHat'
+    - (ansible_distribution_major_version | version_compare ('5','<'))
+  tags:
+    - haproxy-repos
 
 # New repo for haproxy is only needed if Ubuntu or Debian < Jessie
 - include: haproxy_add_apt_repo.yml
-  when: >
+  when:
     ansible_distribution == 'Ubuntu' or
     (ansible_distribution == 'Debian' and (ansible_distribution_major_version | version_compare ('8','<')))
+  tags:
+    - haproxy-repos

--- a/tasks/haproxy_ssl.yml
+++ b/tasks/haproxy_ssl.yml
@@ -18,7 +18,7 @@
     path: "{{ haproxy_ssl_cert | dirname }}"
   register: sslcertfolder
   tags:
-    - haproxy-ssl
+    - haproxy-ssl-certfolder
 
 - name: Creating folder ssl cert folder
   file:
@@ -26,14 +26,14 @@
     state: directory
   when: sslcertfolder.stat.exists is undefined
   tags:
-    - haproxy-ssl
+    - haproxy-ssl-certfolder
 
 - name: Making sure ssl key folder exist
   stat:
     path: "{{ haproxy_ssl_key | dirname }}"
   register: sslkeyfolder
   tags:
-    - haproxy-ssl
+    - haproxy-ssl-keyfolder
 
 - name: Creating folder ssl key folder
   file:
@@ -41,14 +41,14 @@
     state: directory
   when: sslkeyfolder.stat.exists is undefined
   tags:
-    - haproxy-ssl
+    - haproxy-ssl-keyfolder
 
 - name: Making sure ssl pem folder exist
   stat:
     path: "{{ haproxy_ssl_pem | dirname }}"
   register: sslpemfolder
   tags:
-    - haproxy-ssl
+    - haproxy-ssl-pemfolder
 
 - name: Creating folder ssl pem folder
   file:
@@ -56,11 +56,15 @@
     state: directory
   when: sslpemfolder.stat.exists is undefined
   tags:
-    - haproxy-ssl
+    - haproxy-ssl-pemfolder
 
 - include: haproxy_ssl_self_signed.yml
   when:
     - haproxy_ssl | bool
     - haproxy_user_ssl_cert is undefined or haproxy_user_ssl_key is undefined
+  tags:
+    - haproxy-ssl-self-signed
 
 - include: haproxy_ssl_user_provided.yml
+  tags:
+    - haproxy-ssl-user-provided

--- a/tasks/haproxy_ssl_self_signed.yml
+++ b/tasks/haproxy_ssl_self_signed.yml
@@ -23,8 +23,6 @@
     - "{{ haproxy_ssl_cert }}"
   when: haproxy_ssl_self_signed_regen | bool
   tags:
-    - haproxy-ssl
-    - haproxy-ssl-self-signed
     - haproxy-ssl-self-signed-regenerate
 
 - name: Create self-signed ssl cert if no certificate exists
@@ -38,8 +36,6 @@
     creates={{ haproxy_ssl_cert }}
   when: haproxy_user_ssl_cert is undefined or haproxy_user_ssl_key is undefined
   tags:
-    - haproxy-ssl
-    - haproxy-ssl-self-signed
     - haproxy-ssl-self-signed-generate
   notify:
     - regen pem

--- a/tasks/haproxy_ssl_user_provided.yml
+++ b/tasks/haproxy_ssl_user_provided.yml
@@ -24,8 +24,7 @@
     - haproxy_user_ssl_cert | default({})
     - haproxy_user_ssl_key | default({})
   tags:
-    - haproxy-ssl
-    - haproxy-ssl-user-provided
+    - haproxy-ssl-user-provided-certcopy
   notify:
     - regen pem
 
@@ -40,8 +39,7 @@
     - haproxy_user_ssl_cert | default({})
     - haproxy_user_ssl_key | default({})
   tags:
-    - haproxy-ssl
-    - haproxy-ssl-user-provided
+    - haproxy-ssl-user-provided-keycopy
   notify:
     - regen pem
 
@@ -54,7 +52,6 @@
     mode: "0644"
   when: haproxy_user_ssl_ca_cert is defined
   tags:
-    - haproxy-ssl
-    - haproxy-ssl-user-provided
+    - haproxy-ssl-user-provided-cacopy
   notify:
     - regen pem

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,8 +21,22 @@
    - "{{ ansible_os_family }}.yml"
    - "default.yml"
 
-- include: haproxy_add_repo.yml
+- include: haproxy_pre_install.yml
+  when: haproxy_pre_install | bool
+  tags:
+    - haproxy-pre-install
+
 - include: haproxy_install.yml
-- include: haproxy_ssl.yml
-  when: haproxy_ssl | bool
+  when: haproxy_install | bool
+  tags:
+    - haproxy-install
+
 - include: haproxy_post_install.yml
+  when: haproxy_post_install | bool
+  tags:
+    - haproxy-post-install
+
+- include: haproxy_config.yml
+  when: haproxy_config | bool
+  tags:
+    - haproxy-config


### PR DESCRIPTION
Also this would allow blocks of tasks to run conditionally without
the need of ansible2.

The role is now split in pre install, install, post install and configure.

It's now possible to run only a block when asked.
